### PR TITLE
feat: add cheers social feature with friend challenges

### DIFF
--- a/src/auth/PrivateRoutesWrapper.tsx
+++ b/src/auth/PrivateRoutesWrapper.tsx
@@ -20,6 +20,7 @@ interface UserTypes {
   last_name: string | null;
   role: "user" | "admin" | "superadmin";
   longest_streak: number;
+  avatar_url: string | null;
   created_at?: string;
 }
 
@@ -44,6 +45,7 @@ const PrivateRoutesWrapper = () => {
       const email = user.primaryEmailAddress?.emailAddress || null;
       const firstName = user.firstName || null;
       const lastName = user.lastName || null;
+      const avatarUrl = user.imageUrl || null;
       setFirstName(firstName);
       setLastName(lastName);
       if (!email) return;
@@ -68,6 +70,7 @@ const PrivateRoutesWrapper = () => {
             email,
             first_name: firstName,
             last_name: lastName,
+            avatar_url: avatarUrl,
             role: "user",
           };
 
@@ -107,6 +110,14 @@ const PrivateRoutesWrapper = () => {
           setLastName(newUserData.last_name ?? lastName);
           setIsHydrated(true);
         } else {
+          // Sync avatar_url from Clerk on each login
+          if (avatarUrl && avatarUrl !== data.avatar_url) {
+            await supabase
+              .from("users")
+              .update({ avatar_url: avatarUrl })
+              .eq("id", data.id);
+          }
+
           setSupabaseId(data.id);
           setLongestStreak(data.longest_streak || 0);
           setRole(data.role);

--- a/src/components/challenges/ChallengeCard.scss
+++ b/src/components/challenges/ChallengeCard.scss
@@ -77,6 +77,46 @@
     }
   }
   }
+  .card-cheers {
+    display: flex;
+    align-items: center;
+    margin-right: 4px;
+    flex-shrink: 0;
+
+    &_avatar {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: 1.5px solid #fff;
+      color: #fff;
+      font-family: "Work Sans";
+      font-size: 7px;
+      font-weight: 700;
+      line-height: 1;
+      margin-left: -5px;
+      overflow: hidden;
+
+      &:first-child {
+        margin-left: 0;
+      }
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    }
+
+    &_overflow {
+      background: rgba(26, 26, 26, 0.15);
+      color: rgba(26, 26, 26, 0.8);
+      font-size: 7px;
+    }
+  }
+
   .card-status {
     display: flex;
     // padding-top: 4px;

--- a/src/components/challenges/ChallengeCard.tsx
+++ b/src/components/challenges/ChallengeCard.tsx
@@ -9,9 +9,7 @@ import greyCheckmark from "@/assets/icons/checkmark-grey-circle.svg";
 import greyEllipsis from "@/assets/images/vertical-ellipsis-grey.png";
 import EditPencil from "@/assets/images/edit-pencil-grey.png";
 import DeleteTrashcan from "@/assets/images/delete-trashcan-grey.png";
-// @ts-expect-error: This import is temporarily unused, but may be used in the future for the Invite button.
 import addUser from "@/assets/icons/user-add.svg";
-import addUserDisabled from "@/assets/icons/user-add-disabled.svg";
 //Router
 import { Link } from "react-router-dom";
 //Utils
@@ -31,7 +29,9 @@ import {
   useModalsStore,
   useDashboardStore,
   useUserStore,
+  useSocialStore,
 } from "@/stores";
+import { getInitials, getAvatarColor } from "@/utils/avatar";
 
 type Props = {
   challenge: Challenge;
@@ -58,6 +58,10 @@ const ChallengeCard = ({ challenge }: Props) => {
   const { openDropdownId, toggleDropdownId } = useDropdownStore();
   const isOpen = openDropdownId === challenge.id;
   const { activeTab } = useDashboardStore();
+  const { receivedCheers } = useSocialStore();
+  const cardCheers = receivedCheers.filter(
+    (c) => c.challenge_log_id === challenge.id
+  );
 
   // Calculate display info for past challenges
   const pastChallengeDisplay =
@@ -199,6 +203,39 @@ const ChallengeCard = ({ challenge }: Props) => {
           </p>
         </div>
       </Link>
+      {cardCheers.length > 0 && (
+        <div className="card-cheers">
+          {cardCheers.slice(0, 3).map((cheer) => {
+            const initials = getInitials(cheer.first_name, cheer.last_name);
+            const color = getAvatarColor(cheer.user_id);
+            const name =
+              `${cheer.first_name ?? ""} ${cheer.last_name ?? ""}`.trim();
+            return (
+              <div
+                key={cheer.user_id}
+                className="card-cheers_avatar"
+                style={
+                  cheer.avatar_url
+                    ? undefined
+                    : { backgroundColor: color }
+                }
+                title={name}
+              >
+                {cheer.avatar_url ? (
+                  <img src={cheer.avatar_url} alt={name} />
+                ) : (
+                  initials
+                )}
+              </div>
+            );
+          })}
+          {cardCheers.length > 3 && (
+            <div className="card-cheers_avatar card-cheers_overflow">
+              +{cardCheers.length - 3}
+            </div>
+          )}
+        </div>
+      )}
       <div className="card-status">
         <button
           ref={doneButtonRef}
@@ -243,18 +280,12 @@ const ChallengeCard = ({ challenge }: Props) => {
                   </button>
                 )}
               </li>
-              {/* <li role="none">
-                <button role="menuitem">
-                  <img src={addUser} />
-                  <p>Invite</p>
-                </button>
-              </li> */}
               <li role="none">
                 <button
                   className="dropdown_invite-button-disabled"
                   role="menuitem"
                 >
-                  <img src={addUserDisabled} />
+                  <img src={addUser} />
                   <p>Invite</p>
                   <span>COMING SOON</span>
                 </button>

--- a/src/components/challenges/ChallengerForm.tsx
+++ b/src/components/challenges/ChallengerForm.tsx
@@ -56,10 +56,8 @@ const ChallengerForm = ({ onClose }: ChallengerFormTypes) => {
   const { user } = useUser();
   const clerkId = useUserStore((s) => s.clerkId);
   const supabaseId = useUserStore((s) => s.supabaseId);
-  const userRole = useUserStore((s) => s.role);
   const firstName = useUserStore((s) => s.firstName);
   const { fetchChallenges } = useChallengesStore();
-  const isAdmin = userRole === "admin" || userRole === "superadmin";
   const standinUserName = user?.primaryEmailAddress?.emailAddress.split("@")[0];
   const [challenge, setChallenge] = useState<string>("");
   const [pseudoDeadline, setPseudoDeadline] = useState<Date | undefined>(

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export * from "./challenges";
 export * from "./landing";
 export * from "./dashboard";
 export * from "./modals";
+export * from "./social";

--- a/src/components/social/CheerButton.scss
+++ b/src/components/social/CheerButton.scss
@@ -1,0 +1,29 @@
+@use "@/styles/_variables.scss" as *;
+
+.cheer-button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 16px;
+  border: 1px solid rgba(26, 26, 26, 0.15);
+  background: transparent;
+  cursor: pointer;
+  font-family: "Work Sans";
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  color: rgba(26, 26, 26, 0.7);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+
+  &:hover {
+    background: rgba(26, 26, 26, 0.05);
+  }
+
+  &--active {
+    background: rgba(255, 215, 0, 0.1);
+    border-color: rgba(255, 215, 0, 0.3);
+    color: rgba(26, 26, 26, 0.9);
+  }
+}

--- a/src/components/social/CheerButton.tsx
+++ b/src/components/social/CheerButton.tsx
@@ -1,0 +1,47 @@
+import { useRef } from "react";
+import { useReward } from "partycles";
+import "./CheerButton.scss";
+
+type CheerButtonProps = {
+  isCheered: boolean;
+  onToggle: () => void;
+};
+
+const CheerButton = ({ isCheered, onToggle }: CheerButtonProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const { reward } = useReward(
+    buttonRef as React.RefObject<HTMLElement>,
+    "stars",
+    {
+      particleCount: 25,
+      spread: 160,
+      startVelocity: 3,
+      elementSize: 12,
+      lifetime: 120,
+      physics: { gravity: 0.5, wind: 0, friction: 0.98 },
+      colors: ["#FFD700", "#FFA500", "#FF6347"],
+    }
+  );
+
+  const handleClick = () => {
+    if (!isCheered) {
+      reward();
+    }
+    onToggle();
+  };
+
+  return (
+    <button
+      ref={buttonRef}
+      onClick={handleClick}
+      className={`cheer-button ${isCheered ? "cheer-button--active" : ""}`}
+      aria-label={isCheered ? "Remove cheer" : "Cheer"}
+    >
+      <span>{isCheered ? "🎉" : "👏"}</span>
+      <span>{isCheered ? "Cheered" : "Cheer"}</span>
+    </button>
+  );
+};
+
+export default CheerButton;

--- a/src/components/social/CheersAvatarGroup.scss
+++ b/src/components/social/CheersAvatarGroup.scss
@@ -1,0 +1,38 @@
+@use "@/styles/_variables.scss" as *;
+
+.cheers-avatar-group_avatars {
+  display: flex;
+}
+
+.cheers-avatar-group_avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid #f1f5f9;
+  color: #fff;
+  font-family: "Work Sans";
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  margin-left: -6px;
+  overflow: hidden;
+
+  &:first-child {
+    margin-left: 0;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.cheers-avatar-group_overflow {
+  background: rgba(26, 26, 26, 0.15);
+  color: rgba(26, 26, 26, 0.8);
+  font-size: 8px;
+}

--- a/src/components/social/CheersAvatarGroup.tsx
+++ b/src/components/social/CheersAvatarGroup.tsx
@@ -1,0 +1,65 @@
+import "./CheersAvatarGroup.scss";
+import { getInitials, getAvatarColor } from "@/utils/avatar";
+import { useSocialStore } from "@/stores";
+
+const CheersAvatarGroup = () => {
+  const { receivedCheers } = useSocialStore();
+
+  const uniqueCheerers = receivedCheers.reduce(
+    (acc, cheer) => {
+      if (!acc.find((c) => c.user_id === cheer.user_id)) {
+        acc.push(cheer);
+      }
+      return acc;
+    },
+    [] as typeof receivedCheers
+  );
+
+  if (uniqueCheerers.length === 0) {
+    return <p>No cheers yet</p>;
+  }
+
+  const displayCount = Math.min(uniqueCheerers.length, 5);
+  const overflow = uniqueCheerers.length - displayCount;
+
+  return (
+    <>
+      <p>
+        {uniqueCheerers.length} cheer{uniqueCheerers.length !== 1 ? "s" : ""}
+      </p>
+      <div className="cheers-avatar-group_avatars">
+        {uniqueCheerers.slice(0, displayCount).map((cheer) => {
+          const initials = getInitials(cheer.first_name, cheer.last_name);
+          const color = getAvatarColor(cheer.user_id);
+          const name =
+            `${cheer.first_name ?? ""} ${cheer.last_name ?? ""}`.trim();
+          return (
+            <div
+              key={cheer.user_id}
+              className="cheers-avatar-group_avatar"
+              style={
+                cheer.avatar_url
+                  ? undefined
+                  : { backgroundColor: color }
+              }
+              title={name}
+            >
+              {cheer.avatar_url ? (
+                <img src={cheer.avatar_url} alt={name} />
+              ) : (
+                initials
+              )}
+            </div>
+          );
+        })}
+        {overflow > 0 && (
+          <div className="cheers-avatar-group_avatar cheers-avatar-group_overflow">
+            +{overflow}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default CheersAvatarGroup;

--- a/src/components/social/FriendChallengeCard.scss
+++ b/src/components/social/FriendChallengeCard.scss
@@ -1,0 +1,75 @@
+@use "@/styles/_variables.scss" as *;
+
+.friend-challenge-card {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: $divider;
+
+  &:first-child {
+    border-top: $divider;
+  }
+
+  &_avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    border-radius: 50%;
+    color: #fff;
+    font-family: "Work Sans";
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    margin-right: 8px;
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  &_info {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &_emoji {
+    margin-right: 8px;
+    flex-shrink: 0;
+    font-size: 16px;
+  }
+
+  &_titles {
+    @include flex-column(2px);
+    min-width: 0;
+    flex: 1;
+
+    h4 {
+      overflow: hidden;
+      color: rgba(26, 26, 26, 0.9);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-family: "Work Sans";
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 20px;
+      letter-spacing: 0.14px;
+    }
+
+    p {
+      color: rgba(26, 26, 26, 0.65);
+      font-family: Asap;
+      font-size: 10px;
+      font-weight: 400;
+      line-height: 12px;
+      letter-spacing: 0.1px;
+    }
+  }
+}

--- a/src/components/social/FriendChallengeCard.tsx
+++ b/src/components/social/FriendChallengeCard.tsx
@@ -1,0 +1,57 @@
+import "./FriendChallengeCard.scss";
+import { getInitials, getAvatarColor } from "@/utils/avatar";
+import { getDeadlineDisplay } from "@/utils/deadlineDisplay";
+import CheerButton from "./CheerButton";
+import type { FriendChallenge } from "@/types";
+
+type FriendChallengeCardProps = {
+  challenge: FriendChallenge;
+  isCheered: boolean;
+  onToggleCheer: () => void;
+};
+
+const FriendChallengeCard = ({
+  challenge,
+  isCheered,
+  onToggleCheer,
+}: FriendChallengeCardProps) => {
+  const initials = getInitials(
+    challenge.friend_first_name,
+    challenge.friend_last_name
+  );
+  const color = getAvatarColor(challenge.user_id);
+  const friendName = challenge.friend_first_name
+    ? `${challenge.friend_first_name}${challenge.friend_last_name ? ` ${challenge.friend_last_name.charAt(0)}.` : ""}`
+    : "Friend";
+
+  return (
+    <div className="friend-challenge-card">
+      <div
+        className="friend-challenge-card_avatar"
+        style={challenge.friend_avatar_url ? undefined : { backgroundColor: color }}
+      >
+        {challenge.friend_avatar_url ? (
+          <img src={challenge.friend_avatar_url} alt={friendName} />
+        ) : (
+          initials
+        )}
+      </div>
+      <div className="friend-challenge-card_info">
+        <span className="friend-challenge-card_emoji">{challenge.emoji}</span>
+        <div className="friend-challenge-card_titles">
+          <h4>{challenge.title}</h4>
+          <p>
+            {friendName} &middot;{" "}
+            {getDeadlineDisplay(new Date(challenge.deadline))} left
+          </p>
+        </div>
+      </div>
+      <CheerButton
+        isCheered={isCheered}
+        onToggle={onToggleCheer}
+      />
+    </div>
+  );
+};
+
+export default FriendChallengeCard;

--- a/src/components/social/index.ts
+++ b/src/components/social/index.ts
@@ -1,0 +1,3 @@
+export { default as CheerButton } from "./CheerButton";
+export { default as FriendChallengeCard } from "./FriendChallengeCard";
+export { default as CheersAvatarGroup } from "./CheersAvatarGroup";

--- a/src/pages/Home.scss
+++ b/src/pages/Home.scss
@@ -260,6 +260,34 @@
     }
   }
 
+  .dashboard_friends-challenges {
+    @include flex-column(16px);
+    padding: 0 16px 60px;
+
+    &_header {
+      @include flex-column(4px);
+      color: rgba(26, 26, 26, 0.9);
+      font-family: Asap;
+
+      h2 {
+        font-size: 20px;
+        font-weight: 700;
+        line-height: 28px;
+      }
+
+      h3 {
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 16px;
+        letter-spacing: 0.12px;
+      }
+    }
+
+    &_cards-container {
+      @include flex-column;
+    }
+  }
+
   .dashboard-kyurem_cta {
     @include flex-column(12px);
     align-items: center;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,20 +6,20 @@ import { calculateCurrentStreak } from "@/utils/calculateStreak";
 //Styles
 import "./Home.scss";
 import { AnimatePresence, motion } from "framer-motion";
-import PlaceHolderAvatarGroup from "@/assets/images/PlaceHolderAvatarGroup.jpg";
 import plusCircle from "@/assets/images/plus-black-circle-white.png";
 import plusSoft from "@/assets/icons/plus-white-circle-grey.svg";
 //Auth
 import { useUser } from "@clerk/clerk-react";
 //Zustand
 import { useUserStore } from "@/stores/user";
-import { useChallengesStore, useDashboardStore } from "@/stores";
+import { useChallengesStore, useDashboardStore, useSocialStore } from "@/stores";
 //Supabase
 import { supabase } from "@/supabase-client";
 //Components
 import { NavSpacer, CarraigeLoader, Button } from "@/components/shared";
 import { ChallengerForm, ChallengeCard } from "@/components/challenges";
 import { DashboardEmptyExamples, DashboardCTAFooter } from "@/components/dashboard";
+import { CheersAvatarGroup, FriendChallengeCard } from "@/components/social";
 
 const Home = () => {
   const {
@@ -52,13 +52,68 @@ const Home = () => {
   const [editLastName, setEditLastName] = useState("");
   const [isSavingName, setIsSavingName] = useState(false);
 
+  /* ----------------------------- Social State ------------------------------ */
+
+  const {
+    friends,
+    friendsChallenges,
+    fetchFriends,
+    fetchFriendsChallenges,
+    fetchReceivedCheers,
+    addCheer,
+    removeCheer,
+  } = useSocialStore();
+
+  const [myCheerSet, setMyCheerSet] = useState<Set<string>>(new Set());
+
   /* ----------------------- Fetch Challenges useEffect ----------------------- */
 
   useEffect(() => {
     // TODO: Add skeleton state
     if (!supabaseId) return; // ensures valid UUID before fetching
     fetchChallenges(supabaseId);
+    fetchFriends(supabaseId);
   }, [supabaseId]);
+
+  useEffect(() => {
+    if (friends.length === 0) return;
+    fetchFriendsChallenges(friends.map((f) => f.id));
+  }, [friends]);
+
+  useEffect(() => {
+    if (currentChallenges.length === 0) return;
+    fetchReceivedCheers(currentChallenges.map((c) => c.id));
+  }, [currentChallenges]);
+
+  useEffect(() => {
+    if (!supabaseId || friendsChallenges.length === 0) return;
+    const logIds = friendsChallenges.map((fc) => fc.id);
+    supabase
+      .from("cheers")
+      .select("challenge_log_id")
+      .eq("user_id", supabaseId)
+      .in("challenge_log_id", logIds)
+      .then(({ data, error }) => {
+        if (!error && data) {
+          setMyCheerSet(new Set(data.map((d) => d.challenge_log_id)));
+        }
+      });
+  }, [supabaseId, friendsChallenges]);
+
+  const handleToggleCheer = async (challengeLogId: string) => {
+    if (!supabaseId) return;
+    if (myCheerSet.has(challengeLogId)) {
+      setMyCheerSet((prev) => {
+        const next = new Set(prev);
+        next.delete(challengeLogId);
+        return next;
+      });
+      await removeCheer(challengeLogId, supabaseId);
+    } else {
+      setMyCheerSet((prev) => new Set(prev).add(challengeLogId));
+      await addCheer(challengeLogId, supabaseId);
+    }
+  };
 
   /* -------------------------- Name Edit Functions --------------------------- */
 
@@ -188,9 +243,7 @@ const Home = () => {
             <p>{currentStreak} days</p>
             <p>Longest streak: {longestStreak} days</p>
             <div className="dashboard-user_streak-cheers">
-              <p>No cheers yet</p>
-              {/* Pictures of friends cheering will be here */}
-              <img src={PlaceHolderAvatarGroup} />
+              <CheersAvatarGroup />
             </div>
           </div>
         </div>
@@ -198,50 +251,70 @@ const Home = () => {
       {!challenges.length ? (
         <DashboardEmptyExamples />
       ) : (
-        <section className="dashboard_challenges-display">
-          <div className="dashboard_challenges-display_header">
-            <h2>{activeTab === "past" && "Past"} Challenges</h2>
-            {activeTab === "current" ? (
-              <h3>Show your fellow chaps you are true to your word</h3>
-            ) : (
-              <h3>Come to admire your work, I see.</h3>
-            )}
-          </div>
-          <div className={activeTab === "current" ? "visible" : "hidden"}>
-            {currentChallenges.length === 0 ? (
-              <div className="dashboard_challenges-display_new-cta">
-                <p>You’ve done it! Splendid work.</p>
-                <p>Now then — pip pip, and on to the next!</p>
-                <Button
-                  icon={plusCircle}
-                  onClick={() => setIsChallengerFormOpen(true)}
-                >
-                  Create a challenge
-                </Button>
-              </div>
-            ) : (
+        <>
+          <section className="dashboard_challenges-display">
+            <div className="dashboard_challenges-display_header">
+              <h2>{activeTab === "past" && "Past"} Challenges</h2>
+              {activeTab === "current" ? (
+                <h3>Show your fellow chaps you are true to your word</h3>
+              ) : (
+                <h3>Come to admire your work, I see.</h3>
+              )}
+            </div>
+            <div className={activeTab === "current" ? "visible" : "hidden"}>
+              {currentChallenges.length === 0 ? (
+                <div className="dashboard_challenges-display_new-cta">
+                  <p>You’ve done it! Splendid work.</p>
+                  <p>Now then — pip pip, and on to the next!</p>
+                  <Button
+                    icon={plusCircle}
+                    onClick={() => setIsChallengerFormOpen(true)}
+                  >
+                    Create a challenge
+                  </Button>
+                </div>
+              ) : (
+                <div className="dashboard_challenges-display_cards-container">
+                  {currentChallenges.map((c) => {
+                    return <ChallengeCard key={c.id} challenge={c} />;
+                  })}
+                  <button
+                    onClick={() => setIsChallengerFormOpen(true)}
+                    className="dashboard_challenges-display_cards-container_new-challenge-card"
+                  >
+                    <img src={plusSoft} />
+                    <span>New challenge</span>
+                  </button>
+                </div>
+              )}
+            </div>
+            <div className={activeTab === "past" ? "visible" : "hidden"}>
               <div className="dashboard_challenges-display_cards-container">
-                {currentChallenges.map((c) => {
+                {pastChallenges.map((c) => {
                   return <ChallengeCard key={c.id} challenge={c} />;
                 })}
-                <button
-                  onClick={() => setIsChallengerFormOpen(true)}
-                  className="dashboard_challenges-display_cards-container_new-challenge-card"
-                >
-                  <img src={plusSoft} />
-                  <span>New challenge</span>
-                </button>
               </div>
-            )}
-          </div>
-          <div className={activeTab === "past" ? "visible" : "hidden"}>
-            <div className="dashboard_challenges-display_cards-container">
-              {pastChallenges.map((c) => {
-                return <ChallengeCard key={c.id} challenge={c} />;
-              })}
             </div>
-          </div>
-        </section>
+          </section>
+          {friendsChallenges.length > 0 && (
+            <section className="dashboard_friends-challenges">
+              <div className="dashboard_friends-challenges_header">
+                <h2>Friends’ Challenges</h2>
+                <h3>Give your mates a jolly good cheer</h3>
+              </div>
+              <div className="dashboard_friends-challenges_cards-container">
+                {friendsChallenges.map((fc) => (
+                  <FriendChallengeCard
+                    key={fc.id}
+                    challenge={fc}
+                    isCheered={myCheerSet.has(fc.id)}
+                    onToggleCheer={() => handleToggleCheer(fc.id)}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+        </>
       )}
 
       {/* Footer */}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -7,5 +7,8 @@ export * from "./user";
 // UI stores
 export * from "./ui";
 
+// Social stores
+export * from "./social";
+
 // Dashboard store
 export { useDashboardStore } from "./dashboardStore";

--- a/src/stores/social/index.ts
+++ b/src/stores/social/index.ts
@@ -1,0 +1,1 @@
+export { default as useSocialStore } from "./socialStore";

--- a/src/stores/social/socialStore.ts
+++ b/src/stores/social/socialStore.ts
@@ -1,0 +1,195 @@
+import { create } from "zustand";
+import { supabase } from "@/supabase-client";
+import type { FriendUser, FriendChallenge, ReceivedCheer } from "@/types";
+
+interface SocialStoreProps {
+  friends: FriendUser[];
+  friendsChallenges: FriendChallenge[];
+  receivedCheers: ReceivedCheer[];
+  fetchFriends: (userId: string) => Promise<void>;
+  fetchFriendsChallenges: (friendIds: string[]) => Promise<void>;
+  fetchReceivedCheers: (challengeLogIds: string[]) => Promise<void>;
+  addCheer: (challengeLogId: string, userId: string) => Promise<void>;
+  removeCheer: (challengeLogId: string, userId: string) => Promise<void>;
+}
+
+const useSocialStore = create<SocialStoreProps>((set, get) => ({
+  friends: [],
+  friendsChallenges: [],
+  receivedCheers: [],
+
+  fetchFriends: async (userId: string) => {
+    try {
+      const { data: friendships, error: fError } = await supabase
+        .from("friendships")
+        .select("user_id, friend_id")
+        .eq("status", "accepted")
+        .or(`user_id.eq.${userId},friend_id.eq.${userId}`);
+
+      if (fError || !friendships) {
+        console.error("Failed to fetch friendships", fError);
+        return;
+      }
+
+      const friendIds = friendships.map((f) =>
+        f.user_id === userId ? f.friend_id : f.user_id
+      );
+
+      if (friendIds.length === 0) {
+        set({ friends: [] });
+        return;
+      }
+
+      const { data: users, error: uError } = await supabase
+        .from("users")
+        .select("id, first_name, last_name, avatar_url")
+        .in("id", friendIds);
+
+      if (uError || !users) {
+        console.error("Failed to fetch friend users", uError);
+        return;
+      }
+
+      set({ friends: users });
+    } catch (err) {
+      console.error("Unexpected error in fetchFriends:", err);
+    }
+  },
+
+  fetchFriendsChallenges: async (friendIds: string[]) => {
+    try {
+      if (friendIds.length === 0) {
+        set({ friendsChallenges: [] });
+        return;
+      }
+
+      const now = new Date().toISOString();
+
+      const { data: logs, error: logError } = await supabase
+        .from("challenge_logs")
+        .select("id, challenge_id, user_id, deadline, is_completed, is_failed, emoji")
+        .in("user_id", friendIds)
+        .eq("is_completed", false)
+        .eq("is_failed", false)
+        .gt("deadline", now);
+
+      if (logError || !logs) {
+        console.error("Failed to fetch friends' challenge logs", logError);
+        return;
+      }
+
+      if (logs.length === 0) {
+        set({ friendsChallenges: [] });
+        return;
+      }
+
+      const challengeIds = [...new Set(logs.map((l) => l.challenge_id))];
+      const { data: challenges, error: cError } = await supabase
+        .from("challenges")
+        .select("id, title")
+        .in("id", challengeIds);
+
+      if (cError || !challenges) {
+        console.error("Failed to fetch challenge titles", cError);
+        return;
+      }
+
+      const { friends } = get();
+
+      const enriched: FriendChallenge[] = logs.map((log) => {
+        const challenge = challenges.find((c) => c.id === log.challenge_id);
+        const friend = friends.find((f) => f.id === log.user_id);
+        return {
+          id: log.id,
+          challenge_id: log.challenge_id,
+          user_id: log.user_id,
+          title: challenge?.title ?? "Untitled",
+          emoji: log.emoji ?? "",
+          deadline: log.deadline,
+          is_completed: log.is_completed,
+          is_failed: log.is_failed,
+          friend_first_name: friend?.first_name ?? null,
+          friend_last_name: friend?.last_name ?? null,
+          friend_avatar_url: friend?.avatar_url ?? null,
+        };
+      });
+
+      set({ friendsChallenges: enriched });
+    } catch (err) {
+      console.error("Unexpected error in fetchFriendsChallenges:", err);
+    }
+  },
+
+  fetchReceivedCheers: async (challengeLogIds: string[]) => {
+    try {
+      if (challengeLogIds.length === 0) {
+        set({ receivedCheers: [] });
+        return;
+      }
+
+      const { data: cheers, error: cheerError } = await supabase
+        .from("cheers")
+        .select("id, challenge_log_id, user_id, created_at")
+        .in("challenge_log_id", challengeLogIds);
+
+      if (cheerError || !cheers) {
+        console.error("Failed to fetch received cheers", cheerError);
+        return;
+      }
+
+      if (cheers.length === 0) {
+        set({ receivedCheers: [] });
+        return;
+      }
+
+      const cheererIds = [...new Set(cheers.map((c) => c.user_id))];
+      const { data: users, error: uError } = await supabase
+        .from("users")
+        .select("id, first_name, last_name, avatar_url")
+        .in("id", cheererIds);
+
+      if (uError || !users) {
+        console.error("Failed to fetch cheerer users", uError);
+        return;
+      }
+
+      const enriched: ReceivedCheer[] = cheers.map((cheer) => {
+        const user = users.find((u) => u.id === cheer.user_id);
+        return {
+          ...cheer,
+          first_name: user?.first_name ?? null,
+          last_name: user?.last_name ?? null,
+          avatar_url: user?.avatar_url ?? null,
+        };
+      });
+
+      set({ receivedCheers: enriched });
+    } catch (err) {
+      console.error("Unexpected error in fetchReceivedCheers:", err);
+    }
+  },
+
+  addCheer: async (challengeLogId: string, userId: string) => {
+    const { error } = await supabase
+      .from("cheers")
+      .insert({ challenge_log_id: challengeLogId, user_id: userId });
+
+    if (error) {
+      console.error("Failed to add cheer", error);
+    }
+  },
+
+  removeCheer: async (challengeLogId: string, userId: string) => {
+    const { error } = await supabase
+      .from("cheers")
+      .delete()
+      .eq("challenge_log_id", challengeLogId)
+      .eq("user_id", userId);
+
+    if (error) {
+      console.error("Failed to remove cheer", error);
+    }
+  },
+}));
+
+export default useSocialStore;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./challenge";
 export * from "./user";
+export * from "./social";

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -1,0 +1,55 @@
+export type FriendUser = {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  avatar_url: string | null;
+};
+
+export type Friendship = {
+  id: string;
+  user_id: string;
+  friend_id: string;
+  status: "pending" | "accepted";
+  created_at: string;
+  accepted_at: string | null;
+};
+
+export type FriendChallenge = {
+  id: string;
+  challenge_id: string;
+  user_id: string;
+  title: string;
+  emoji: string;
+  deadline: string;
+  is_completed: boolean;
+  is_failed: boolean;
+  friend_first_name: string | null;
+  friend_last_name: string | null;
+  friend_avatar_url: string | null;
+};
+
+export type Cheer = {
+  id: string;
+  challenge_log_id: string;
+  user_id: string;
+  created_at: string;
+};
+
+export type ReceivedCheer = {
+  id: string;
+  challenge_log_id: string;
+  user_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  avatar_url: string | null;
+  created_at: string;
+};
+
+export type ChallengeInvite = {
+  id: string;
+  challenge_id: string;
+  inviter_id: string;
+  invitee_id: string;
+  status: "pending" | "accepted" | "declined";
+  created_at: string;
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -6,4 +6,5 @@ export type User = {
   longest_streak: number;
   role: string | null;
   created_at: string;
+  avatar_url: string | null;
 };

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,29 @@
+const AVATAR_COLORS = [
+  "#6366f1",
+  "#8b5cf6",
+  "#ec4899",
+  "#f43f5e",
+  "#14b8a6",
+  "#06b6d4",
+  "#f59e0b",
+  "#84cc16",
+  "#10b981",
+  "#3b82f6",
+];
+
+export function getInitials(
+  firstName: string | null,
+  lastName: string | null
+): string {
+  const first = firstName?.charAt(0)?.toUpperCase() ?? "";
+  const last = lastName?.charAt(0)?.toUpperCase() ?? "";
+  return first + last || "?";
+}
+
+export function getAvatarColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = hash + userId.charCodeAt(i);
+  }
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+}

--- a/supabase/migrations/20260322_add_avatar_url_to_users.sql
+++ b/supabase/migrations/20260322_add_avatar_url_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url TEXT;


### PR DESCRIPTION
## Summary
- **Friends' Challenges section** below user's own challenges — view active challenges from accepted friends and cheer them with a confetti-animated button
- **Cheers avatar group** in the dashboard header showing profile pictures of friends who cheered your challenges
- **Cheers on challenge cards** — small avatar row on each card showing who cheered that specific challenge
- **Avatar URL sync** — profile pictures pulled from Clerk and stored in Supabase on login, with initials fallback
- **Invite button scaffold** — visible in challenge dropdown as "COMING SOON"

## New files
- `src/types/social.ts` — FriendUser, FriendChallenge, Cheer, ReceivedCheer, ChallengeInvite types
- `src/stores/social/socialStore.ts` — Zustand store for friends, challenges, and cheers
- `src/components/social/` — CheerButton, FriendChallengeCard, CheersAvatarGroup
- `src/utils/avatar.ts` — initials + deterministic color helpers
- `supabase/migrations/20260322_add_avatar_url_to_users.sql`

## Modified files
- `Home.tsx/scss` — integrated friends section + cheers avatar group
- `ChallengeCard.tsx/scss` — shows cheers avatars per card
- `PrivateRoutesWrapper.tsx` — syncs avatar_url from Clerk on login
- `ChallengerForm.tsx` — fixed pre-existing unused variable error

## Test plan
- [ ] Insert accepted friendship row in Supabase between two accounts
- [ ] Verify friends' challenges section appears below user's challenges
- [ ] Verify cheer button triggers confetti and persists to DB
- [ ] Verify cheers avatar group shows in dashboard header
- [ ] Verify cheers show on individual challenge cards
- [ ] Verify avatar URLs sync after logging into both accounts
- [ ] `npm run build` passes clean