### PR TITLE
feat: add skeleton loading and friends empty state

### DIFF
--- a/src/components/shared/DashboardSkeleton.scss
+++ b/src/components/shared/DashboardSkeleton.scss
@@ -1,0 +1,97 @@
+@use "@/styles/_variables.scss" as *;
+
+.dashboard-skeleton {
+  @include flex-column;
+
+  &_header {
+    @include flex-column(12px);
+    @include padding-eights;
+  }
+
+  &_time {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &_user {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 12px;
+    padding-bottom: 16px;
+    background: #f1f5f9;
+    border-radius: 8px;
+  }
+
+  &_name {
+    @include flex-column(4px);
+    padding-top: 2px;
+    max-width: 200px;
+  }
+
+  &_streak {
+    @include flex-column;
+    padding-top: 6px;
+    width: 33%;
+
+    .skeleton:nth-child(1) {
+      margin-bottom: 2px;
+    }
+
+    .skeleton:nth-child(2) {
+      margin-bottom: 1px;
+    }
+
+    .skeleton:nth-child(3) {
+      margin-bottom: 16px;
+    }
+  }
+
+  &_cheers {
+    @include flex-column(4px);
+  }
+
+  &_cheers-avatars {
+    display: flex;
+
+    .skeleton {
+      margin-left: -6px;
+      border: 2px solid #f1f5f9;
+
+      &:first-child {
+        margin-left: 0;
+      }
+    }
+  }
+
+  &_challenges {
+    @include flex-column(16px);
+    padding: 16px;
+  }
+
+  &_challenges-header {
+    @include flex-column(4px);
+  }
+
+  &_cards {
+    @include flex-column;
+  }
+
+  &_card {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    padding-right: 0;
+    border-bottom: $divider;
+
+    &:first-child {
+      border-top: $divider;
+    }
+  }
+
+  &_card-text {
+    @include flex-column(4px);
+    flex: 1;
+  }
+}

--- a/src/components/shared/DashboardSkeleton.tsx
+++ b/src/components/shared/DashboardSkeleton.tsx
@@ -1,0 +1,58 @@
+import Skeleton from "./Skeleton";
+import "./DashboardSkeleton.scss";
+
+export const ChallengesSkeleton = () => {
+  return (
+    <div className="dashboard-skeleton_cards" role="status" aria-label="Loading challenges">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="dashboard-skeleton_card">
+          <Skeleton width="20px" height="20px" borderRadius="4px" delay={i * 0.15} />
+          <div className="dashboard-skeleton_card-text">
+            <Skeleton width={`${70 - i * 15}%`} height="20px" delay={i * 0.15} />
+            <Skeleton width="80px" height="12px" delay={i * 0.15} />
+          </div>
+          <Skeleton width="48px" height="20px" borderRadius="4px" delay={i * 0.15} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const DashboardSkeleton = () => {
+  return (
+    <div className="dashboard-skeleton" role="status" aria-label="Loading dashboard">
+      {/* Time row */}
+      <section className="dashboard-skeleton_header">
+        <div className="dashboard-skeleton_time">
+          <Skeleton width="120px" height="16px" />
+          <Skeleton width="90px" height="16px" />
+        </div>
+
+        {/* User card */}
+        <div className="dashboard-skeleton_user">
+          <div className="dashboard-skeleton_name">
+            <Skeleton width="80px" height="16px" />
+            <Skeleton width="140px" height="30px" borderRadius="6px" />
+          </div>
+          <div className="dashboard-skeleton_streak">
+            <Skeleton width="70px" height="14px" />
+            <Skeleton width="50px" height="24px" borderRadius="6px" />
+            <Skeleton width="90px" height="14px" />
+            <div className="dashboard-skeleton_cheers">
+              <Skeleton width="58px" height="14px" />
+              <div className="dashboard-skeleton_cheers-avatars">
+                <Skeleton width="24px" height="24px" borderRadius="50%" />
+                <Skeleton width="24px" height="24px" borderRadius="50%" />
+                <Skeleton width="24px" height="24px" borderRadius="50%" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <ChallengesSkeleton />
+    </div>
+  );
+};
+
+export default DashboardSkeleton;

--- a/src/components/shared/Skeleton.scss
+++ b/src/components/shared/Skeleton.scss
@@ -1,0 +1,24 @@
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(26, 26, 26, 0.12) 0%,
+    rgba(26, 26, 26, 0.05) 40%,
+    rgba(26, 26, 26, 0.12) 80%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.8s ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background: rgba(26, 26, 26, 0.12);
+  }
+}

--- a/src/components/shared/Skeleton.tsx
+++ b/src/components/shared/Skeleton.tsx
@@ -1,0 +1,31 @@
+import "./Skeleton.scss";
+
+type SkeletonProps = {
+  width?: string;
+  height?: string;
+  borderRadius?: string;
+  className?: string;
+  delay?: number;
+};
+
+const Skeleton = ({
+  width = "100%",
+  height = "16px",
+  borderRadius = "4px",
+  className = "",
+  delay = 0,
+}: SkeletonProps) => {
+  return (
+    <div
+      className={`skeleton ${className}`}
+      style={{
+        width,
+        height,
+        borderRadius,
+        animationDelay: delay ? `${delay}s` : undefined,
+      }}
+    />
+  );
+};
+
+export default Skeleton;

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -6,3 +6,5 @@ export { default as CursorInput } from "./CursorInput";
 export { default as LoadingWrapper } from "./LoadingWrapper";
 export { default as Overlay } from "./Overlay";
 export { default as ModalPortal } from "./ModalPortal";
+export { default as Skeleton } from "./Skeleton";
+export { default as DashboardSkeleton, ChallengesSkeleton } from "./DashboardSkeleton";

--- a/src/pages/Home.scss
+++ b/src/pages/Home.scss
@@ -286,6 +286,61 @@
     &_cards-container {
       @include flex-column;
     }
+
+    &_empty {
+      color: rgba(26, 26, 26, 0.5);
+      font-family: Asap;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 16px;
+      letter-spacing: 0.12px;
+    }
+
+    &_connect {
+      @include flex-column(8px);
+      align-items: center;
+      padding: 32px 16px;
+      text-align: center;
+
+      p {
+        color: rgba(26, 26, 26, 0.7);
+        font-family: Asap;
+        font-size: 13px;
+        font-weight: 500;
+        line-height: 18px;
+        letter-spacing: 0.13px;
+      }
+
+      &-btn {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 4px;
+        padding: 8px 20px;
+        border-radius: 8px;
+        border: 1px solid rgba(26, 26, 26, 0.15);
+        background: transparent;
+        color: rgba(26, 26, 26, 0.35);
+        font-family: "Work Sans";
+        font-size: 13px;
+        font-weight: 600;
+        line-height: 18px;
+        letter-spacing: 0.13px;
+        cursor: not-allowed;
+
+        span {
+          padding: 1px 6px;
+          border-radius: 8px;
+          background: rgba(26, 26, 26, 0.05);
+          color: rgba(26, 26, 26, 0.7);
+          font-family: "Work Sans";
+          font-size: 10px;
+          font-weight: 600;
+          line-height: 14px;
+          letter-spacing: 0.1px;
+        }
+      }
+    }
   }
 
   .dashboard-kyurem_cta {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,7 +16,7 @@ import { useChallengesStore, useDashboardStore, useSocialStore } from "@/stores"
 //Supabase
 import { supabase } from "@/supabase-client";
 //Components
-import { NavSpacer, CarraigeLoader, Button } from "@/components/shared";
+import { NavSpacer, CarraigeLoader, Button, ChallengesSkeleton, Skeleton } from "@/components/shared";
 import { ChallengerForm, ChallengeCard } from "@/components/challenges";
 import { DashboardEmptyExamples, DashboardCTAFooter } from "@/components/dashboard";
 import { CheersAvatarGroup, FriendChallengeCard } from "@/components/social";
@@ -27,6 +27,7 @@ const Home = () => {
     currentChallenges,
     pastChallenges,
     fetchChallenges,
+    isLoading,
   } = useChallengesStore();
 
   const [isChallengerFormOpen, setIsChallengerFormOpen] = useState(false);
@@ -69,7 +70,6 @@ const Home = () => {
   /* ----------------------- Fetch Challenges useEffect ----------------------- */
 
   useEffect(() => {
-    // TODO: Add skeleton state
     if (!supabaseId) return; // ensures valid UUID before fetching
     fetchChallenges(supabaseId);
     fetchFriends(supabaseId);
@@ -185,70 +185,103 @@ const Home = () => {
         </div>
         <div className="dashboard-user">
           <div className="dashboard-user_name">
-            <p>{greeting}</p>
-            <AnimatePresence mode="wait">
-              {isEditingName ? (
-                <motion.div
-                  key="edit-mode"
-                  className="dashboard-user_name-edit"
-                  initial={{ opacity: 0, y: -10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -10 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <input
-                    type="text"
-                    placeholder="First name"
-                    value={editFirstName}
-                    onChange={(e) => setEditFirstName(e.target.value)}
-                    disabled={isSavingName}
-                    autoFocus
-                  />
-                  <input
-                    type="text"
-                    placeholder="Last name"
-                    value={editLastName}
-                    onChange={(e) => setEditLastName(e.target.value)}
-                    disabled={isSavingName}
-                  />
-                  <div className="dashboard-user_name-edit-buttons">
-                    <button onClick={handleSaveName} disabled={isSavingName}>
-                      {isSavingName ? "Saving..." : "Save"}
-                    </button>
-                    <button onClick={handleCancelEdit} disabled={isSavingName}>
-                      Cancel
-                    </button>
-                  </div>
-                </motion.div>
-              ) : (
-                <motion.p
-                  key="display-mode"
-                  onClick={handleEditName}
-                  style={{ cursor: "pointer" }}
-                  title="Click to edit"
-                  initial={{ opacity: 0, y: -10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -10 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  {firstName || lastName
-                    ? `${firstName || ""} ${lastName || ""}`.trim()
-                    : standinUserName ?? clerkId}
-                </motion.p>
-              )}
-            </AnimatePresence>
+            {isLoading ? (
+              <>
+                <Skeleton width="80px" height="16px" />
+                <Skeleton width="140px" height="30px" borderRadius="6px" />
+              </>
+            ) : (
+              <>
+                <p>{greeting}</p>
+                <AnimatePresence mode="wait">
+                  {isEditingName ? (
+                    <motion.div
+                      key="edit-mode"
+                      className="dashboard-user_name-edit"
+                      initial={{ opacity: 0, y: -10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -10 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <input
+                        type="text"
+                        placeholder="First name"
+                        value={editFirstName}
+                        onChange={(e) => setEditFirstName(e.target.value)}
+                        disabled={isSavingName}
+                        autoFocus
+                      />
+                      <input
+                        type="text"
+                        placeholder="Last name"
+                        value={editLastName}
+                        onChange={(e) => setEditLastName(e.target.value)}
+                        disabled={isSavingName}
+                      />
+                      <div className="dashboard-user_name-edit-buttons">
+                        <button onClick={handleSaveName} disabled={isSavingName}>
+                          {isSavingName ? "Saving..." : "Save"}
+                        </button>
+                        <button onClick={handleCancelEdit} disabled={isSavingName}>
+                          Cancel
+                        </button>
+                      </div>
+                    </motion.div>
+                  ) : (
+                    <motion.p
+                      key="display-mode"
+                      onClick={handleEditName}
+                      style={{ cursor: "pointer" }}
+                      title="Click to edit"
+                      initial={{ opacity: 0, y: -10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -10 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {firstName || lastName
+                        ? `${firstName || ""} ${lastName || ""}`.trim()
+                        : standinUserName ?? clerkId}
+                    </motion.p>
+                  )}
+                </AnimatePresence>
+              </>
+            )}
           </div>
           <div className="dashboard-user_streak">
             <p>Current streak</p>
             <p>{currentStreak} days</p>
             <p>Longest streak: {longestStreak} days</p>
             <div className="dashboard-user_streak-cheers">
-              <CheersAvatarGroup />
+              {isLoading ? (
+                <>
+                  <Skeleton width="58px" height="14px" />
+                  <Skeleton width="58px" height="24px" borderRadius="12px" />
+                </>
+              ) : (
+                <CheersAvatarGroup />
+              )}
             </div>
           </div>
         </div>
       </section>
-      {!challenges.length ? (
+      {isLoading ? (
+        <>
+          <section className="dashboard_challenges-display">
+            <div className="dashboard_challenges-display_header">
+              <h2>Challenges</h2>
+              <h3>Show your fellow chaps you are true to your word</h3>
+            </div>
+            <ChallengesSkeleton />
+          </section>
+          <section className="dashboard_friends-challenges">
+            <div className="dashboard_friends-challenges_header">
+              <h2>Friends’ Challenges</h2>
+              <h3>Give your mates a jolly good cheer</h3>
+            </div>
+            <ChallengesSkeleton />
+          </section>
+        </>
+      ) : !challenges.length ? (
         <DashboardEmptyExamples />
       ) : (
         <>
@@ -296,12 +329,12 @@ const Home = () => {
               </div>
             </div>
           </section>
-          {friendsChallenges.length > 0 && (
-            <section className="dashboard_friends-challenges">
-              <div className="dashboard_friends-challenges_header">
-                <h2>Friends’ Challenges</h2>
-                <h3>Give your mates a jolly good cheer</h3>
-              </div>
+          <section className="dashboard_friends-challenges">
+            <div className="dashboard_friends-challenges_header">
+              <h2>Friends’ Challenges</h2>
+              <h3>Give your mates a jolly good cheer</h3>
+            </div>
+            {friendsChallenges.length > 0 ? (
               <div className="dashboard_friends-challenges_cards-container">
                 {friendsChallenges.map((fc) => (
                   <FriendChallengeCard
@@ -312,13 +345,28 @@ const Home = () => {
                   />
                 ))}
               </div>
-            </section>
-          )}
+            ) : friends.length > 0 ? (
+              <p className="dashboard_friends-challenges_empty">
+                Your mates are resting — no active challenges at the moment.
+              </p>
+            ) : (
+              <div className="dashboard_friends-challenges_connect">
+                <p>No mates yet? Every gentleman starts somewhere.</p>
+                <button
+                  className="dashboard_friends-challenges_connect-btn"
+                  disabled
+                >
+                  Invite friends
+                  <span>COMING SOON</span>
+                </button>
+              </div>
+            )}
+          </section>
         </>
       )}
 
       {/* Footer */}
-      {!challenges.length ? (
+      {isLoading ? null : !challenges.length ? (
         <section className="dashboard-kyurem_cta">
           <h2>New are you? Start here:</h2>
           <Button

--- a/src/stores/challenges/challengesStore.ts
+++ b/src/stores/challenges/challengesStore.ts
@@ -12,6 +12,7 @@ interface ChallengesProps {
   pastChallenges: Challenge[];
   needsUserAction: Challenge[];
   recurringChallenges: RecurringChallenge[];
+  isLoading: boolean;
   fetchChallenges: (supabaseUserId: string) => Promise<void>;
 }
 
@@ -21,7 +22,9 @@ const useChallengesStore = create<ChallengesProps>((set) => ({
   pastChallenges: [],
   needsUserAction: [],
   recurringChallenges: [],
+  isLoading: true,
   fetchChallenges: async (supabaseUserId: string) => {
+    set({ isLoading: true });
     try {
       const { data: logs, error: logError } = await supabase
         .from("challenge_logs")
@@ -109,9 +112,11 @@ const useChallengesStore = create<ChallengesProps>((set) => ({
         pastChallenges: past,
         needsUserAction: needsUserAction,
         recurringChallenges: recurringData,
+        isLoading: false,
       });
     } catch (err) {
       console.error("Unexpected error in fetchChallenges:", err);
+      set({ isLoading: false });
     }
   },
 }));


### PR DESCRIPTION
## Summary
- **Progressive skeleton loading** — header renders immediately, challenge sections show shimmer placeholders while data fetches, eliminating the empty-state flash on login
- **Reusable Skeleton primitive** with configurable dimensions, staggered animation delays, and `prefers-reduced-motion` support
- **Friends empty state** — always-visible section with brand-voice copy and disabled "Invite friends" button (COMING SOON)

## New files
- `src/components/shared/Skeleton.tsx` + `.scss` — reusable skeleton primitive
- `src/components/shared/DashboardSkeleton.tsx` + `.scss` — composed challenge card skeletons

## Modified files
- `src/stores/challenges/challengesStore.ts` — added `isLoading` state
- `src/pages/Home.tsx` — progressive loading: skeleton greeting/cheers/cards, friends empty state
- `src/pages/Home.scss` — friends empty state + connect CTA styles
- `src/components/shared/index.ts` — barrel exports

## Test plan
- [ ] Login and verify skeleton shows briefly before challenges load
- [ ] Header greeting/name area shows skeleton, streak numbers show immediately
- [ ] Cheers area shows skeleton placeholder during load
- [ ] Both "Challenges" and "Friends' Challenges" headers visible during load
- [ ] Delete friendship row — verify empty state with "Invite friends" button appears
- [ ] `prefers-reduced-motion` disables shimmer animation
- [ ] `npm run build` passes clean